### PR TITLE
Enable double buffering on data grids

### DIFF
--- a/LoadOrder/UI/AssetDataGrid.cs
+++ b/LoadOrder/UI/AssetDataGrid.cs
@@ -27,6 +27,10 @@ namespace LoadOrderTool.UI {
         private DataGridViewTextBoxColumn cStatus;
 
         public AssetDataGrid() {
+
+            // Drastically improve redraw performance
+            DoubleBuffered = true;
+
             cIncluded = new DataGridViewCheckBoxColumn();
             cAssetID = new DataGridViewLinkColumn();
             cName = new DataGridViewTextBoxColumn();

--- a/LoadOrder/UI/ModDataGrid.cs
+++ b/LoadOrder/UI/ModDataGrid.cs
@@ -27,6 +27,10 @@ namespace LoadOrderTool.UI {
         public DataGridViewTextBoxColumn CStatus;
 
         public ModDataGrid() {
+
+            // Drastically improve redraw performance
+            DoubleBuffered = true;
+
             COrder = new DataGridViewTextBoxColumn();
             CIsIncluded = new DataGridViewCheckBoxColumn();
             CEnabled = new DataGridViewCheckBoxColumn();


### PR DESCRIPTION
Enabling double buffering drastically improves the visual performance of the asset and mod views and doesn't seem to have any significant drawbacks or resource usage differences.

Would appear to fix #5  